### PR TITLE
- Added support to library initialization argument

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,14 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>2.2-beta-5</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
 				<configuration>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>

--- a/src/main/java/org/robotframework/remoteserver/xmlrpc/ReflectiveHandlerMapping.java
+++ b/src/main/java/org/robotframework/remoteserver/xmlrpc/ReflectiveHandlerMapping.java
@@ -26,7 +26,7 @@ public class ReflectiveHandlerMapping extends AbstractReflectiveHandlerMapping {
 
     /**
      * Removes the prefixes from all keys in this handler mapping assuming a String was used as the key and period was
-     * used as a separator. Example: AccountsReceivable.Billing.getInvoice -> getInvoice
+     * used as a separator. Example: AccountsReceivable.Billing.getInvoice -&gt; getInvoice
      */
     @SuppressWarnings("unchecked")
     public void removePrefixes() {


### PR DESCRIPTION
Enhanced the command-line syntax to allow a string argument to initialize the library.
E.g.
```
java org.robotframework.remoteserver.RemoteServer --library MyLibrary:/:arg
```